### PR TITLE
Convert canResolve into static isResolvable

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -434,15 +434,15 @@ class Uri {
     }
 
     /**
-     * Is the specified URI string resolvable against the current URI instance?
+     * Test whether the specified value is a valid URI.
      */
-    public static function isResolvable($toResolve) {
-        if (!(is_string($toResolve) || method_exists($toResolve, '__toString'))) {
+    public static function isValid($uri) {
+        if (!(is_string($uri) || method_exists($uri, '__toString'))) {
             return false;
         }
 
         try {
-            (new Uri($toResolve));
+            (new Uri($uri));
         } catch (\DomainException $e) {
             return false;
         }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -207,23 +207,6 @@ class Uri {
         return str_replace($encoded, $decoded, $str);
     }
 
-	/**
-     * Is the specified URI string resolvable against the current URI instance?
-     */
-    public function canResolve($toResolve) {
-        if (!(is_string($toResolve) || method_exists($toResolve, '__toString'))) {
-            return false;
-        }
-
-        try {
-            (new Uri($toResolve));
-        } catch (\DomainException $e) {
-            return false;
-        }
-
-        return true;
-    }
-
     /**
      * @param string $toResolve
      * @return Uri
@@ -448,5 +431,22 @@ class Uri {
      */
     public function getOriginalUri() {
         return $this->uri;
+    }
+
+    /**
+     * Is the specified URI string resolvable against the current URI instance?
+     */
+    public static function isResolvable($toResolve) {
+        if (!(is_string($toResolve) || method_exists($toResolve, '__toString'))) {
+            return false;
+        }
+
+        try {
+            (new Uri($toResolve));
+        } catch (\DomainException $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
@DaveRandom @PeeHaa @bwoebi Do we even need such a method? Seems rather pointless to me.

The first condition should throw an exception instead, as the argument is invalid. And the later one just checks whether it's a valid URI then. So maybe turn the first into an exception and the rename it to `isWellformed` or `isValid`? It doesn't have anything to do with the current URI.
