### PR TITLE
Support `\Amp\Uri\Uri::setScheme`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: false
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
   - nightly
 
 matrix:
@@ -13,16 +15,15 @@ matrix:
   fast_finish: true
 
 before_script:
-  # --ignore-platform-reqs, because https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2722
-  - composer update -n --prefer-dist --ignore-platform-reqs
-  - composer require satooshi/php-coveralls dev-master --ignore-platform-reqs
+  - composer update --no-interaction --prefer-dist
+  - composer require php-coveralls/php-coveralls
 
 script:
   - phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - php vendor/bin/php-coveralls -v
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "friendsofphp/php-cs-fixer": "^2.15.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -276,7 +276,7 @@ class UriTest extends TestCase {
 
     public function testIsValidDnsName() {
         $this->assertTrue(isValidDnsName('google.com'));
-        $this->assertFalse(isValidDnsName('google.com.'));
+        $this->assertFalse(isValidDnsName('google.com..'));
     }
 
     public function testInvalidUriException() {
@@ -301,6 +301,6 @@ class UriTest extends TestCase {
 
     public function testInvalidDnsNameException() {
         $this->expectException(InvalidDnsNameException::class);
-        normalizeDnsName('google.com.');
+        normalizeDnsName('google.com。。');
     }
 }


### PR DESCRIPTION
Support `\Amp\Uri\Uri::setScheme`.

For [example](https://github.com/felixfbecker/php-language-server/blob/9dc16565922ae1fcf18a69b15b3cd15152ea21e6/src/ComposerScripts.php#L54-L56):
```php
$uri = new \Amp\Uri\Uri('file:///tmp/JetBrains/phpstorm-stubs/Core/Core.php');
$uri->setPath('Core/Core.php');
$uri->setScheme('phpstubs');

echo $uri;
```